### PR TITLE
handle gracefully a serial read returning 'None'

### DIFF
--- a/src/ticlib/ticlib.py
+++ b/src/ticlib/ticlib.py
@@ -542,7 +542,9 @@ class TicSerial(TicBase):
         # Read the returned value
         result = self._read_response(length)
         # Verify and format the returned value
-        if len(result) != length:
+        if result is None:
+            raise RuntimeError("Read response returned 'None', read likely timed out")
+        elif len(result) != length:
             raise RuntimeError("Expected to read {} bytes, got {}.".format(length, len(result)))
         if format_response is None:
             return result


### PR DESCRIPTION
In micropython, a UART.read() timing out returns 'None'. Raising a RuntimeError with a meaningful message seems to be better than getting an exception when attempting to get the len() of a None type.