### PR TITLE
Bugfix/typeannotation fix for getters

### DIFF
--- a/src/ticlib/ticlib.py
+++ b/src/ticlib/ticlib.py
@@ -198,9 +198,9 @@ GET_SETTING_CMD = 0xA8
 VARIABLES = [
     # General status  -------------------------------------
     ('operation_state', 0x00, 1, unsigned_int),
-    ('misc_flags', 0x01, 1, None),
-    ('error_status', 0x02, 2, None),
-    ('error_occured', 0x04, 4, None),
+    ('misc_flags', 0x01, 1, bit_range(0,4)),
+    ('error_status', 0x02, 2, bit_range(0,8)),
+    ('error_occured', 0x04, 4, bit_range(0,19)),
 
     # Step planning ---------------------------------------
     ('planning_mode', 0x09, 1, unsigned_int),
@@ -225,8 +225,8 @@ VARIABLES = [
     ('analog_reading_sda', 0x41, 2, unsigned_int),
     ('analog_reading_tx', 0x43, 2, unsigned_int),
     ('analog_reading_rx', 0x45, 2, unsigned_int),
-    ('digital_readings', 0x47, 1, None),
-    ('pin_states', 0x48, 1, None),
+    ('digital_readings', 0x47, 1, bit_range(0,4)),
+    ('pin_states', 0x48, 1, bit_range(0,7)),
     ('step_mode', 0x49, 1, unsigned_int),
     ('current_limit', 0x4A, 1, unsigned_int),
     ('decay_mode', 0x4B, 1, unsigned_int),  # Not valid for 36v4

--- a/src/ticlib/ticlib.py
+++ b/src/ticlib/ticlib.py
@@ -198,9 +198,9 @@ GET_SETTING_CMD = 0xA8
 VARIABLES = [
     # General status  -------------------------------------
     ('operation_state', 0x00, 1, unsigned_int),
-    ('misc_flags', 0x01, 1, partial(bit_range(0,4))),
-    ('error_status', 0x02, 2, partial(bit_range(0,8))),
-    ('error_occured', 0x04, 4, partial(bit_range(0,19))),
+    ('misc_flags', 0x01, 1, partial(bit_range,0,4)),
+    ('error_status', 0x02, 2, partial(bit_range,0,8)),
+    ('error_occured', 0x04, 4, partial(bit_range,0,19)),
 
     # Step planning ---------------------------------------
     ('planning_mode', 0x09, 1, unsigned_int),
@@ -225,8 +225,8 @@ VARIABLES = [
     ('analog_reading_sda', 0x41, 2, unsigned_int),
     ('analog_reading_tx', 0x43, 2, unsigned_int),
     ('analog_reading_rx', 0x45, 2, unsigned_int),
-    ('digital_readings', 0x47, 1, partial(bit_range(0,4))),
-    ('pin_states', 0x48, 1, partial(bit_range(0,7))),
+    ('digital_readings', 0x47, 1, partial(bit_range,0,4)),
+    ('pin_states', 0x48, 1, partial(bit_range,0,7)),
     ('step_mode', 0x49, 1, unsigned_int),
     ('current_limit', 0x4A, 1, unsigned_int),
     ('decay_mode', 0x4B, 1, unsigned_int),  # Not valid for 36v4
@@ -243,7 +243,7 @@ VARIABLES = [
     ('agc_frequency_limit', 0x59, 1, unsigned_int),
 
     # 36v4-only -------------------------------------------
-    ('last_hp_driver_errors', 0xFF, 1, partial(bit_range(0,7))),
+    ('last_hp_driver_errors', 0xFF, 1, partial(bit_range,0,7)),
 ]
 
 

--- a/src/ticlib/ticlib.py
+++ b/src/ticlib/ticlib.py
@@ -243,7 +243,7 @@ VARIABLES = [
     ('agc_frequency_limit', 0x59, 1, unsigned_int),
 
     # 36v4-only -------------------------------------------
-    ('last_hp_driver_errors', 0xFF, 1, None),
+    ('last_hp_driver_errors', 0xFF, 1, bit_range(0,7)),
 ]
 
 

--- a/src/ticlib/ticlib.py
+++ b/src/ticlib/ticlib.py
@@ -198,9 +198,9 @@ GET_SETTING_CMD = 0xA8
 VARIABLES = [
     # General status  -------------------------------------
     ('operation_state', 0x00, 1, unsigned_int),
-    ('misc_flags', 0x01, 1, bit_range(0,4)),
-    ('error_status', 0x02, 2, bit_range(0,8)),
-    ('error_occured', 0x04, 4, bit_range(0,19)),
+    ('misc_flags', 0x01, 1, partial(bit_range(0,4))),
+    ('error_status', 0x02, 2, partial(bit_range(0,8))),
+    ('error_occured', 0x04, 4, partial(bit_range(0,19))),
 
     # Step planning ---------------------------------------
     ('planning_mode', 0x09, 1, unsigned_int),
@@ -225,8 +225,8 @@ VARIABLES = [
     ('analog_reading_sda', 0x41, 2, unsigned_int),
     ('analog_reading_tx', 0x43, 2, unsigned_int),
     ('analog_reading_rx', 0x45, 2, unsigned_int),
-    ('digital_readings', 0x47, 1, bit_range(0,4)),
-    ('pin_states', 0x48, 1, bit_range(0,7)),
+    ('digital_readings', 0x47, 1, partial(bit_range(0,4))),
+    ('pin_states', 0x48, 1, partial(bit_range(0,7))),
     ('step_mode', 0x49, 1, unsigned_int),
     ('current_limit', 0x4A, 1, unsigned_int),
     ('decay_mode', 0x4B, 1, unsigned_int),  # Not valid for 36v4
@@ -243,7 +243,7 @@ VARIABLES = [
     ('agc_frequency_limit', 0x59, 1, unsigned_int),
 
     # 36v4-only -------------------------------------------
-    ('last_hp_driver_errors', 0xFF, 1, bit_range(0,7)),
+    ('last_hp_driver_errors', 0xFF, 1, partial(bit_range(0,7))),
 ]
 
 


### PR DESCRIPTION
This pull request updates the variable definitions in `src/ticlib/ticlib.py` to improve type safety and clarity by replacing `None` formatters with explicit `bit_range` formatters for several status and state variables. These changes ensure that bit fields are correctly interpreted and parsed, making the codebase more robust and maintainable.

**Improvements to variable formatters:**

* Changed the formatter for `misc_flags`, `error_status`, and `error_occured` to use `bit_range` with appropriate bit widths, replacing the previous `None` value.
* Updated the `digital_readings` and `pin_states` variables to use `bit_range` formatters to explicitly specify their bit widths.
* Modified the `last_hp_driver_errors` variable to use a `bit_range(0,7)` formatter for improved clarity.